### PR TITLE
Fix std::copy index out of range bug in pystfio Section.asarray()

### DIFF
--- a/src/pystfio/pystfio.i
+++ b/src/pystfio/pystfio.i
@@ -356,8 +356,8 @@ class Section {
         PyObject* np_array = PyArray_SimpleNew(1, dims, NPY_DOUBLE);
         double* gDataP = (double*)array_data(np_array);
 
-        std::copy( &($self->operator[](0)),
-                   &($self->operator[]($self->size())),
+        std::copy( $self->get().begin(),
+                   $self->get().end(),
                    gDataP);
         return np_array;
     };


### PR DESCRIPTION
Hello,

I built a Win64 version of the python stfio module with VS2008, but found that python would die whenever `Section.asarray()` was executed. After wrangling VS2008 and python into building a debug version of the library, I traced this to a bug in `Section.asarray()`. `$self->operator[]($self-size())` was being used to get the last+1 index of the array, but since this index is out of range, `operator[]()` was throwing an exception. The correct method seems to be to use the iterator class `.begin()` and `.end()` methods, as I have done in this commit.

I suspect this issue happens with VS2008 win32 also, but if so, it's strange that you haven't encountered it already. Maybe you build the win32 version with MXE instead of VS2008?

(FYI I successfully used VC2008 Express to build this Win64 version of py-stfio. You can see the changes in my fork, I'll create a separate discussion about this).  
