### PR TITLE
Fix date and time read from ABF2 files

### DIFF
--- a/src/libstfio/abf/abflib.cpp
+++ b/src/libstfio/abf/abflib.cpp
@@ -323,10 +323,12 @@ void stfio::importABF2File(const std::string &fName, Recording &ReturnData, Prog
     ldiv_t year=ldiv(pFH->uFileStartDate,(ABFLONG)10000);
     ldiv_t month=ldiv(year.rem,(ABFLONG)100);
 
-    ldiv_t hours=ldiv(pFH->uFileStartTimeMS,(ABFLONG)3600);
+    ldiv_t hours=ldiv(pFH->uFileStartTimeMS/1000,(ABFLONG)3600);
     ldiv_t minutes=ldiv(hours.rem,(ABFLONG)60);
 
-    ReturnData.SetDateTime(year.quot, month.quot, month.rem, hours.quot, minutes.quot, minutes.rem);
+    // Recording::SetDateTime expects the year to be passed as the number of years since 1900, and the month
+    // as 0 = Jan ... 11 = Dec
+    ReturnData.SetDateTime(year.quot-1900, month.quot-1, month.rem, hours.quot, minutes.quot, minutes.rem);
 
     abf2.Close();
 }


### PR DESCRIPTION
Date and time values are correctly read from the file, but stfio::importABF2File() does not correctly translate these to the format expected by Recording::SetDateTime(). Time is stored in the file as milliseconds after midnight, but the code treats it as seconds. Also, the date is encoded with a four digit year and months from 1-12, whereas Recording::SetDateTime() expects the number of years after 1900 and months from 0-11.

It looks like a similar bug may affect ABF1 files, as stfio::importABF1File() also appears to pass a four digit year and 1-12 month to Recording::SetDateTime(). The hours, minutes and seconds don't seem to be affected in this case as ABF1 time appears to stored in seconds rather than milliseconds. I'm not submitting a fix for this as I don't have an ABF1 file to test with.