### PR TITLE
Update conda packages

### DIFF
--- a/dist/conda/biosig/meta.yaml
+++ b/dist/conda/biosig/meta.yaml
@@ -1,12 +1,10 @@
 package:
     name: biosig
-    version: "1.5.6"
+    version: "1.6.4"
 
 source:
-    fn: biosig4c++-1.5.6.i686-pc-mingw32.zip # [win32]
-    fn: biosig4c++-1.5.6.x86_64-w64-mingw32.zip # [win64]
-    url: "http://downloads.sourceforge.net/project/biosig/BioSig for C_C++/windows/biosig4c++-1.5.6.i686-pc-mingw32.zip" # [win32]
-    url: "http://downloads.sourceforge.net/project/biosig/BioSig for C_C++/windows/biosig4c++-1.5.6.x86_64-w64-mingw32.zip" # [win64]
+    fn: biosig-1.6.4-VS2008-x64.zip # [win64]
+    url: "http://www.stimfit.org/libs/biosig-1.6.4-VS2008-x64.zip" # [win64]
 
 build:
     number: 0

--- a/dist/conda/clapack/bld.bat
+++ b/dist/conda/clapack/bld.bat
@@ -1,0 +1,1 @@
+copy %SRC_DIR%\*.lib %LIBRARY_LIB%\

--- a/dist/conda/clapack/meta.yaml
+++ b/dist/conda/clapack/meta.yaml
@@ -1,0 +1,15 @@
+package:
+    name: clapack
+    version: "3.1.1"
+
+source:
+    fn: CLAPACK-VS2008-x64.zip # [win64]
+    url: "http://www.stimfit.org/libs/CLAPACK-VS2008-x64.zip" # [win64]
+
+build:
+    number: 0
+
+about:
+    home: http://www.netlib.org/clapack/
+    license: Modified BSD
+    summary: "The CLAPACK library was built using a Fortran to C conversion utility called f2c. The entire Fortran 77 LAPACK library is run through f2c to obtain C code, and then modified to improve readability. CLAPACK's goal is to provide LAPACK for someone who does not have access to a Fortran compiler."

--- a/dist/conda/fftw/bld.bat
+++ b/dist/conda/fftw/bld.bat
@@ -1,0 +1,3 @@
+copy %SRC_DIR%\*.lib %LIBRARY_LIB%\
+copy %SRC_DIR%\*.dll %LIBRARY_BIN%\
+xcopy %SRC_DIR%\*.h %LIBRARY_LIB%\

--- a/dist/conda/fftw/meta.yaml
+++ b/dist/conda/fftw/meta.yaml
@@ -1,0 +1,15 @@
+package:
+    name: fftw
+    version: "3.3.4"
+
+source:
+    fn: fftw-3.3.4-VS2008-x64.zip # [win64]
+    url: "http://www.stimfit.org/libs/fftw-3.3.4-VS2008-x64.zip" # [win64]
+
+build:
+    number: 0
+
+about:
+    home: http://www.fftw.org/
+    license: GPL
+    summary: "FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data (as well as of even/odd data, i.e. the discrete cosine/sine transforms or DCT/DST)."

--- a/dist/conda/py-stfio-debug/bld.bat
+++ b/dist/conda/py-stfio-debug/bld.bat
@@ -36,11 +36,14 @@ copy %SRC_DIR%\dist\windows\VS2008\Stimfit\%PLATFORM%\Debug\_stfio.pyd %SP_DIR%\
 copy %SRC_DIR%\dist\windows\VS2008\Stimfit\%PLATFORM%\Debug\_stfio.pdb %SP_DIR%\stfio
 copy %SRC_DIR%\dist\windows\VS2008\Stimfit\%PLATFORM%\Debug\libstfio.dll %SP_DIR%\stfio
 copy %SRC_DIR%\dist\windows\VS2008\Stimfit\%PLATFORM%\Debug\libstfio.pdb %SP_DIR%\stfio
+copy %SRC_DIR%\dist\windows\VS2008\Stimfit\%PLATFORM%\Debug\libstfnum.dll %SP_DIR%\stfio
+copy %SRC_DIR%\dist\windows\VS2008\Stimfit\%PLATFORM%\Debug\libstfnum.pdb %SP_DIR%\stfio
 
-:: The hdf5-dll and biosig conda packages put their DLLs in %LIBRARY_BIN%. Since pystfio depends on these, need
-:: to copy them too
+:: The hdf5-dll, biosig and fftw conda packages put their DLLs in %LIBRARY_BIN%. Since pystfio depends on these,
+:: need to copy them too
 copy %LIBRARY_BIN%\hdf5.dll %SP_DIR%\stfio
 copy %LIBRARY_BIN%\hdf5_hl.dll %SP_DIR%\stfio
 copy %LIBRARY_BIN%\zlib.dll %SP_DIR%\stfio
 copy %LIBRARY_BIN%\szip.dll %SP_DIR%\stfio
 copy %LIBRARY_BIN%\libbiosig2.dll %SP_DIR%\stfio
+copy %LIBRARY_BIN%\libfftw3-3.dll %SP_DIR%\stfio

--- a/dist/conda/py-stfio-debug/meta.yaml
+++ b/dist/conda/py-stfio-debug/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: py-stfio-debug
-    version: "trunk"
+    version: "0.14.9"
 
 source:
     # Since this recipe is part of the git repo, the source is just a local path
@@ -15,6 +15,8 @@ requirements:
     build:
         - hdf5-dll
         - biosig
+        - fftw
+        - clapack
         - python
         - numpy
     run:

--- a/dist/conda/py-stfio-debug/vsprops.patch
+++ b/dist/conda/py-stfio-debug/vsprops.patch
@@ -30,7 +30,12 @@ diff --git dist/windows/VS2008/pystfio/Config.vsprops dist/windows/VS2008/pystfi
 index be1b192..9ced898 100755
 --- dist/windows/VS2008/pystfio/Config.vsprops
 +++ dist/windows/VS2008/pystfio/Config.vsprops
-@@ -15,10 +15,10 @@
+@@ -11,18 +11,18 @@
+ 	/>
+ 	<UserMacro
+ 		Name="NUMPYDIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\stf-site-packages\numpy\core\include"
++		Value="$(PYTHONDIR)\Lib\site-packages\numpy\core\include"
  	/>
  	<UserMacro
  		Name="PYTHONDIR"
@@ -41,5 +46,43 @@ index be1b192..9ced898 100755
  		Name="BOOSTDIR"
 -		Value="$(SolutionDir)\..\..\..\..\..\boost"
 +		Value="$(HOMEDRIVE)$(HOMEPATH)\boost"
+ 	/>
+ 	<UserMacro
+ 		Name="FFTWDIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\fftw"
++		Value="$(LIBRARY_LIB)"
+ 	/>
+ </VisualStudioPropertySheet>
+diff --git dist/windows/VS2008/libstfnum/Config.vsprops dist/windows/VS2008/libstfnum/Config.vsprops
+index be1b192..9ced898 100755
+--- dist/windows/VS2008/libstfnum/Config.vsprops
++++ dist/windows/VS2008/libstfnum/Config.vsprops
+@@ -6,23 +6,23 @@
+ 	>
+ 	<UserMacro
+ 		Name="HDF5DIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\hdf5"
++		Value="$(LIBRARY_INC)\.."
+ 		PerformEnvironmentSet="true"
+ 	/>
+ 	<UserMacro
+ 		Name="FFTWDIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\fftw"
++		Value="$(LIBRARY_LIB)"
+ 	/>
+ 	<UserMacro
+ 		Name="BOOSTDIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\boost"
++		Value="$(HOMEDRIVE)$(HOMEPATH)\boost"
+ 	/>
+ 	<UserMacro
+ 		Name="BIOSIGDIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\biosig"
++		Value="$(LIBRARY_INC)\.."
+ 	/>
+ 	<UserMacro
+ 		Name="PYTHONDIR"
+-		Value="C:\Python27"
++		Value="$(PREFIX)"
  	/>
  </VisualStudioPropertySheet>

--- a/dist/conda/py-stfio/bld.bat
+++ b/dist/conda/py-stfio/bld.bat
@@ -21,12 +21,14 @@ copy %SRC_DIR%\src\pystfio\stfio_neo.py %SP_DIR%\stfio
 copy %SRC_DIR%\src\pystfio\stfio.py %SP_DIR%\stfio
 copy %SRC_DIR%\dist\windows\VS2008\Stimfit\%PLATFORM%\Release\_stfio.pyd %SP_DIR%\stfio
 copy %SRC_DIR%\dist\windows\VS2008\Stimfit\%PLATFORM%\Release\libstfio.dll %SP_DIR%\stfio
+copy %SRC_DIR%\dist\windows\VS2008\Stimfit\%PLATFORM%\Release\libstfnum.dll %SP_DIR%\stfio
 
-:: The hdf5-dll and biosig conda packages put their DLLs in %LIBRARY_BIN%. Since pystfio depends on these, need
-:: to copy them too
+:: The hdf5-dll, biosig and fftw conda packages put their DLLs in %LIBRARY_BIN%. Since pystfio depends on these,
+:: need to copy them too
 copy %LIBRARY_BIN%\hdf5.dll %SP_DIR%\stfio
 copy %LIBRARY_BIN%\hdf5_hl.dll %SP_DIR%\stfio
 copy %LIBRARY_BIN%\zlib.dll %SP_DIR%\stfio
 copy %LIBRARY_BIN%\szip.dll %SP_DIR%\stfio
 copy %LIBRARY_BIN%\libbiosig2.dll %SP_DIR%\stfio
+copy %LIBRARY_BIN%\libfftw3-3.dll %SP_DIR%\stfio
 

--- a/dist/conda/py-stfio/meta.yaml
+++ b/dist/conda/py-stfio/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: py-stfio
-    version: "trunk"
+    version: "0.14.9"
 
 source:
     # Since this recipe is part of the git repo, the source is just a local path
@@ -15,6 +15,8 @@ requirements:
     build:
         - hdf5-dll
         - biosig
+        - fftw
+        - clapack
         - python
         - numpy
     run:

--- a/dist/conda/py-stfio/vsprops.patch
+++ b/dist/conda/py-stfio/vsprops.patch
@@ -30,7 +30,12 @@ diff --git dist/windows/VS2008/pystfio/Config.vsprops dist/windows/VS2008/pystfi
 index be1b192..9ced898 100755
 --- dist/windows/VS2008/pystfio/Config.vsprops
 +++ dist/windows/VS2008/pystfio/Config.vsprops
-@@ -15,10 +15,10 @@
+@@ -11,18 +11,18 @@
+ 	/>
+ 	<UserMacro
+ 		Name="NUMPYDIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\stf-site-packages\numpy\core\include"
++		Value="$(PYTHONDIR)\Lib\site-packages\numpy\core\include"
  	/>
  	<UserMacro
  		Name="PYTHONDIR"
@@ -41,5 +46,43 @@ index be1b192..9ced898 100755
  		Name="BOOSTDIR"
 -		Value="$(SolutionDir)\..\..\..\..\..\boost"
 +		Value="$(HOMEDRIVE)$(HOMEPATH)\boost"
+ 	/>
+ 	<UserMacro
+ 		Name="FFTWDIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\fftw"
++		Value="$(LIBRARY_LIB)"
+ 	/>
+ </VisualStudioPropertySheet>
+diff --git dist/windows/VS2008/libstfnum/Config.vsprops dist/windows/VS2008/libstfnum/Config.vsprops
+index be1b192..9ced898 100755
+--- dist/windows/VS2008/libstfnum/Config.vsprops
++++ dist/windows/VS2008/libstfnum/Config.vsprops
+@@ -6,23 +6,23 @@
+ 	>
+ 	<UserMacro
+ 		Name="HDF5DIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\hdf5"
++		Value="$(LIBRARY_INC)\.."
+ 		PerformEnvironmentSet="true"
+ 	/>
+ 	<UserMacro
+ 		Name="FFTWDIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\fftw"
++		Value="$(LIBRARY_LIB)"
+ 	/>
+ 	<UserMacro
+ 		Name="BOOSTDIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\boost"
++		Value="$(HOMEDRIVE)$(HOMEPATH)\boost"
+ 	/>
+ 	<UserMacro
+ 		Name="BIOSIGDIR"
+-		Value="$(SolutionDir)\..\..\..\..\..\biosig"
++		Value="$(LIBRARY_INC)\.."
+ 	/>
+ 	<UserMacro
+ 		Name="PYTHONDIR"
+-		Value="C:\Python27"
++		Value="$(PREFIX)"
  	/>
  </VisualStudioPropertySheet>


### PR DESCRIPTION
I finally got a chance to update the biosig conda package to use the new Stimfit-provided build. Also, I noticed pystfio now also depends on libstfnum, so I updated the py-stfio packages accordingly. This required adding conda packages for fftw and clapack.

I've put the current version number (0.14.9) as the version number of the py-stfio and py-stfio-debug packages. Ideally, this should be updated whenever the stimfit version is changed. I'm not sure if there's a way to do this automatically across the git repo.