### PR TITLE
update documentation template

### DIFF
--- a/doc/sphinx/.templates/layout.html
+++ b/doc/sphinx/.templates/layout.html
@@ -11,9 +11,10 @@
 {# to show the bar on the left side #}
 {#{{ sidebar() }}#}
 
-{# show the relbar only before the document
-{% block relbar2 %}{{ sidebar() }}{% endblock %}
-#}
+{# show the relbar only before the document #}
+{% block relbar2 %}
+    {{ sidebar() }}
+    {% endblock %}
 
 
 

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -42,7 +42,7 @@ master_doc = 'contents'
 
 # General information about the project.
 project = u'Stimfit'
-copyright = u'2014, Christoph Schmidt-Hieber'
+copyright = u'2015, Christoph Schmidt-Hieber'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -61,7 +61,7 @@ release = '0.14.11'
 # non-false value, then it is used:
 #today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+today_fmt = '%d %B, %Y'
 
 # List of documents that shouldn't be included in the build.
 #unused_docs = []
@@ -128,7 +128,7 @@ html_logo = '../../src/stimfit/res/stimfit_128.png'
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = '%d %B, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.

--- a/doc/sphinx/howto/amplitudes.rst
+++ b/doc/sphinx/howto/amplitudes.rst
@@ -2,8 +2,8 @@
 Calculations on selected traces
 *******************************
 
-:Author: Jose Guzman
-:Date:  |today|
+:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Updated: |today|
 
 A widely used feature of `Stimfit <http://www.stimfit.org>`_ is the selection of some traces of interest within a file to make some calculations on them (average, peaks, amplitudes, etc.). The batch-analysis of `Stimfit <http://www.stimfit.org>`_ does precisely that. However, in some cases we can enhance its possibilities writing our custom functions in Python for the selected traces. 
 

--- a/doc/sphinx/howto/amplitudes.rst
+++ b/doc/sphinx/howto/amplitudes.rst
@@ -2,7 +2,7 @@
 Calculations on selected traces
 *******************************
 
-:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Authors: Jose Guzman
 :Updated: |today|
 
 A widely used feature of `Stimfit <http://www.stimfit.org>`_ is the selection of some traces of interest within a file to make some calculations on them (average, peaks, amplitudes, etc.). The batch-analysis of `Stimfit <http://www.stimfit.org>`_ does precisely that. However, in some cases we can enhance its possibilities writing our custom functions in Python for the selected traces. 

--- a/doc/sphinx/howto/apcounting.rst
+++ b/doc/sphinx/howto/apcounting.rst
@@ -2,8 +2,8 @@
 Event counting
 **************
 
-:Author: Jose Guzman
-:Date:  |today|
+:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Updated: |today|
 
 Counting the number of events (for example action potentials) within a time window is a very common task in electrophysiology. In its simplest form, the user would like to know how many spikes occur following the onset of a stimulus (i.e current injection). We can write a simple Python function which automatically performs this calculation with a simple event detection routine. 
 

--- a/doc/sphinx/howto/apcounting.rst
+++ b/doc/sphinx/howto/apcounting.rst
@@ -2,7 +2,7 @@
 Event counting
 **************
 
-:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Authors: Jose Guzman
 :Updated: |today|
 
 Counting the number of events (for example action potentials) within a time window is a very common task in electrophysiology. In its simplest form, the user would like to know how many spikes occur following the onset of a stimulus (i.e current injection). We can write a simple Python function which automatically performs this calculation with a simple event detection routine. 

--- a/doc/sphinx/howto/ascii.rst
+++ b/doc/sphinx/howto/ascii.rst
@@ -2,8 +2,8 @@
 Loading custom text files
 *************************
 
-:Author: Jose Guzman, Alois Schloegl and Christoph Schmidt-Hieber
-:Date: |today|
+:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Updated: |today|
 
 Very often we want to analyze data in `Stimfit <http://stimfit.org>`_ that is generated from a simulation or stored in non-stardard formats, like for example fluorescence. While `Stimfit <http://stimfit.org>`_ supports a huge variety of file formats, data from more exotic sources can be copied to a text file loaded in with a very simple Python script.
 

--- a/doc/sphinx/howto/ascii.rst
+++ b/doc/sphinx/howto/ascii.rst
@@ -2,7 +2,7 @@
 Loading custom text files
 *************************
 
-:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Authors: Jose Guzman
 :Updated: |today|
 
 Very often we want to analyze data in `Stimfit <http://stimfit.org>`_ that is generated from a simulation or stored in non-stardard formats, like for example fluorescence. While `Stimfit <http://stimfit.org>`_ supports a huge variety of file formats, data from more exotic sources can be copied to a text file loaded in with a very simple Python script.

--- a/doc/sphinx/howto/cuttingtraces.rst
+++ b/doc/sphinx/howto/cuttingtraces.rst
@@ -2,8 +2,8 @@
 Cutting traces
 **************
 
-:Author: Jose Guzman
-:Date:  |today|
+:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Updated: |today|
 
 As described in :doc:`/manual/python` chapter of the :doc:`/manual/index`, a very often requested feature of `Stimfit <http://www.stimfit.org>`_ is to cut an original trace to show it in a presentation or publication. This feature, however, has been only integrated into the stf module, and not in the `Stimfit <http://www.stimfit.org>`_ main menubar. With this, `Stimfit <http://www.stimfit.org>`_ preserves its user interface as clear and user-friendly as possible.
 

--- a/doc/sphinx/howto/cuttingtraces.rst
+++ b/doc/sphinx/howto/cuttingtraces.rst
@@ -2,7 +2,7 @@
 Cutting traces
 **************
 
-:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Authors: Jose Guzman
 :Updated: |today|
 
 As described in :doc:`/manual/python` chapter of the :doc:`/manual/index`, a very often requested feature of `Stimfit <http://www.stimfit.org>`_ is to cut an original trace to show it in a presentation or publication. This feature, however, has been only integrated into the stf module, and not in the `Stimfit <http://www.stimfit.org>`_ main menubar. With this, `Stimfit <http://www.stimfit.org>`_ preserves its user interface as clear and user-friendly as possible.

--- a/doc/sphinx/howto/introclass.rst
+++ b/doc/sphinx/howto/introclass.rst
@@ -2,9 +2,8 @@
 Object oriented programming with Stimfit
 ****************************************
 
-:Author: Jose Guzman
-:Date:  |today|
-
+:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Updated: |today|
 
 Object-oriented programming (OOP) is a software philosophy where the problems are solved with objects rather than with simple functions. These objects  behave similarly to objects in the physical world. For example, image you may want to travel from Freiburg (Germany) to London (UK). For that, you will need to use a transport (e.g car, airplane, etc...) which certain properties (e.g airplanes are much faster than cars, whereas cars are more flexible in terms of schedule). The key concept here is that an object has distinct attributes (associated variables) and methods (associated functions). Interestingly, object attributes are extremely dynamic. They may change as they are involved in different tasks. Because object *have an state* they provide much more versatility to solve problems than static function alone. Thus, in OOP the design of the code is near to the question, and much more far away from the machine and the hardware details.
 

--- a/doc/sphinx/howto/introclass.rst
+++ b/doc/sphinx/howto/introclass.rst
@@ -2,7 +2,7 @@
 Object oriented programming with Stimfit
 ****************************************
 
-:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Authors: Jose Guzman
 :Updated: |today|
 
 Object-oriented programming (OOP) is a software philosophy where the problems are solved with objects rather than with simple functions. These objects  behave similarly to objects in the physical world. For example, image you may want to travel from Freiburg (Germany) to London (UK). For that, you will need to use a transport (e.g car, airplane, etc...) which certain properties (e.g airplanes are much faster than cars, whereas cars are more flexible in terms of schedule). The key concept here is that an object has distinct attributes (associated variables) and methods (associated functions). Interestingly, object attributes are extremely dynamic. They may change as they are involved in different tasks. Because object *have an state* they provide much more versatility to solve problems than static function alone. Thus, in OOP the design of the code is near to the question, and much more far away from the machine and the hardware details.

--- a/doc/sphinx/howto/latencies.rst
+++ b/doc/sphinx/howto/latencies.rst
@@ -2,8 +2,58 @@
 Calculating latencies
 *********************
 
-:Author: Jose Guzman
-:Date:  |today|
+:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Updated: |today|
+
+Very often we want to analyze data in `Stimfit <http://stimfit.org>`_ that is generated from a simulation or stored in non-stardard formats, like for example fluorescence. While `Stimfit <http://stimfit.org>`_ supports a huge variety of file formats, data from more exotic sources can be copied to a text file loaded in with a very simple Python script.
+
+Examples of such cases are NEURON files, which are saved as text files as \*.dat format. Alternatively, users configure custom files formats to, for example, analyze the timecourse of a fluorescent measurement with `Stimfit <https://stimfit.org>`_.  
+
+=========================
+Reading NEURON text files
+=========================
+
+NEURON allows to save a simulation in a very simple text file format. The file consists of a header with two lines containing the event that was recorded and the number of samples. After that, it is followed by the recording time and the sampled data data in a two-column format. To load such a file, we would like to skip the first two rows, and to load the adquisition time.
+
+::
+
+    import stf
+    
+    def loadnrn(file):
+        """
+        Loads a NEURON datafile and opens a new Stimfit window
+        with a trace with the default units (e.g ms and mV)
+
+        file    -- (string) file to read
+        """
+
+        time, trace = np.loadtxt(fname = file, skiprows = 2, unpack= True )
+
+        dt = time[1] # the second temporal sampling point is the sampling
+        stf.new_window( trace )
+        stf.set_sampling_interval( dt )
+
+        
+You can download an example of such a file `here <http://stimfit.org/doc/EPSP.dat>`_
+
+Note that the argument of the function *loadnrn* is a string containing the exact path and filename of the file that we want to load. For very lengthy paths, it can be convenient to write a small gadget that cares about the proper identification of the file. This is what we propose in the section below.
+
+==========================================
+Custom ascii files containing fluorescence 
+==========================================
+
+When creating custom text files to be loaded later, it is generally convenient to take into account the folowing advices:
+
+1. Use a custom extension ( generally dat, .text or similar denote files associated with specific applications).
+2. Add comments that contains the experimental conditions. 
+3. Information about the author and date of file modification can be included in the header inside these comments.
+
+In the example below, a function will load a file with extension \*.GoR that contains fluorescent measurements in time (acquired at 400 Hz). In addition, a small wx gadget will allow us to create a small window to select the file that we want to import. 
+
+::
+
+    import stf
+
 
 `Stimfit <http://www.stimfit.org>`_ was originally used to calculate synaptic latencies (Katz and Miledi, 1965 [#KatzMiledi1965]_) but now can be used to calculate synaptic latencies and latencies between events or action potentials in the same or between different channels (see :doc:`/manual/latency_measurements` in the :doc:`/manual/index`). `Stimfit <http://www.stimfit.org>`_ also provides a very useful collection of Python functions which allow us to easily adapt the latency calculation for our particular conditions. We will use these functions to calculate the latency between two signals in two different channels (e.g. one corresponding to the soma, and another to the dendrite). We will use the object oriented programming paradigm (OOP) to solve this problem and applied it in the embedded Python shell of `Stimfit <http://www.stimfit.org>`_ .  
 

--- a/doc/sphinx/howto/latencies.rst
+++ b/doc/sphinx/howto/latencies.rst
@@ -2,7 +2,7 @@
 Calculating latencies
 *********************
 
-:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Authors: Jose Guzman
 :Updated: |today|
 
 Very often we want to analyze data in `Stimfit <http://stimfit.org>`_ that is generated from a simulation or stored in non-stardard formats, like for example fluorescence. While `Stimfit <http://stimfit.org>`_ supports a huge variety of file formats, data from more exotic sources can be copied to a text file loaded in with a very simple Python script.

--- a/doc/sphinx/howto/resistances.rst
+++ b/doc/sphinx/howto/resistances.rst
@@ -2,8 +2,8 @@
 Resistance Calculation
 **********************
 
-:Author: Jose Guzman
-:Date:  |today|
+:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Updated: |today|
 
 The resistance can be simply calculated using Ohm's law. Currents passing through the pipette will be proportional to the applied voltage difference. This proportional factor is the resistance.  
 

--- a/doc/sphinx/howto/resistances.rst
+++ b/doc/sphinx/howto/resistances.rst
@@ -2,7 +2,7 @@
 Resistance Calculation
 **********************
 
-:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Authors: Jose Guzman
 :Updated: |today|
 
 The resistance can be simply calculated using Ohm's law. Currents passing through the pipette will be proportional to the applied voltage difference. This proportional factor is the resistance.  

--- a/doc/sphinx/howto/runningmean.rst
+++ b/doc/sphinx/howto/runningmean.rst
@@ -2,8 +2,8 @@
 Running mean
 ************
 
-:Author: Jose Guzman
-:Date:  |today|
+:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Updated: |today|
 
 The running mean (or running average) is simple way to smooth the data. Given a certain set of points, a running average will create a new set of data points which will be computed by adding a series of averages of different subsets of the full data set.
 

--- a/doc/sphinx/howto/runningmean.rst
+++ b/doc/sphinx/howto/runningmean.rst
@@ -2,7 +2,7 @@
 Running mean
 ************
 
-:Authors: Jose Guzman, Alois Schlögl and Christoph Schmidt-Hieber
+:Authors: Jose Guzman
 :Updated: |today|
 
 The running mean (or running average) is simple way to smooth the data. Given a certain set of points, a running average will create a new set of data points which will be computed by adding a series of averages of different subsets of the full data set.


### PR DESCRIPTION
Changes in the default documentation template that include updating copyright information (to CSH 2015), removing redundant links on the lower part of the document and updating the list of authors in the book of spells.