### PR TITLE
correct installation instructions for BioSig

### DIFF
--- a/doc/sphinx/linux_install_guide/requirement.rst
+++ b/doc/sphinx/linux_install_guide/requirement.rst
@@ -158,7 +158,8 @@ It is recommended to build `Stimfit <http://www.stimfit.org>`_  with the `BioSig
 
 ::
 
-    sudo make install_libbiosig
+    make 
+    sudo make install
 
 After that you can enter the option --with-biosig in the configure script of `Stimfit <http://www.stimfit.org>`_ and compile as usual.
 


### PR DESCRIPTION
The latest developmental version of BioSig requires the standard make/make install cycle for proper installation. This is now documented in the on line version of the documentation