### PR TITLE
update references

### DIFF
--- a/doc/sphinx/references/index.rst
+++ b/doc/sphinx/references/index.rst
@@ -14,7 +14,6 @@ References
 ====
 2017
 ====
-    * `Schmidt-Hieber C, Toleikyte G, Aitchison L, Roth A, Clark BA, Branco T, Häusser M. (2017) <https://www.nature.com/articles/nn.4582>`_ Active dendritic integration as a mechanism for robust and precise grid cell firing. *Nat Neurosci* 20(8):1114-1121
 
     * `Sinclair JL, Fischl MJ, Alexandrova O, Heβ M, Grothe B, Leibold C, Kopp-Scheinpflug C. (2017) <http://www.jneurosci.org/content/early/2017/07/31/JNEUROSCI.3728-16.2017>`_ Sound-evoked activity influences myelination of brainstem axons in the trapezoid body. *J Neurosci* 23;37(34):8239-8255.
 

--- a/doc/sphinx/references/index.rst
+++ b/doc/sphinx/references/index.rst
@@ -14,6 +14,10 @@ References
 ====
 2017
 ====
+    * `Schmidt-Hieber C, Toleikyte G, Aitchison L, Roth A, Clark BA, Branco T, Häusser M. (2017) <https://www.nature.com/articles/nn.4582>`_ Active dendritic integration as a mechanism for robust and precise grid cell firing. *Nat Neurosci* 20(8):1114-1121
+
+    * `Sinclair JL, Fischl MJ, Alexandrova O, Heβ M, Grothe B, Leibold C, Kopp-Scheinpflug C. (2017) <http://www.jneurosci.org/content/early/2017/07/31/JNEUROSCI.3728-16.2017>`_ Sound-evoked activity influences myelination of brainstem axons in the trapezoid body. *J Neurosci* 23;37(34):8239-8255.
+
     * `Li L, Sultan S, Heigele S, Schmidt-Salzmann C, Toni N, Bischofberger J. (2017) <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5580881/>`_ Silent synapses generate sparse and orthogonal action potential firing in adult-born hippocampal granule cells. *eLife* 2017;6:e23612
 
     * `Schmidt-Hieber C, Toleikyte G, Aitchison L, Roth A, Clark BA, Branco T, Häusser M (2017). <https://www.ncbi.nlm.nih.gov/pubmed/28628104>`_ Active dendritic integration as a mechanism for robust and precise grid cell firing. *Nat Neurosci* 8:1114-1121


### PR DESCRIPTION
Two new references to Schmidt-Hieber et al., 2017 and Sinclair et al., 2017.