### PR TITLE
Updated required versions in Stimfit linux install

### DIFF
--- a/doc/sphinx/linux_install_guide/requirement.rst
+++ b/doc/sphinx/linux_install_guide/requirement.rst
@@ -5,7 +5,7 @@ Building Stimfit
 :Author: Jose Guzman, Christoph Schmidt-Hieber
 :Date:    |today|
 
-This document describes how to install `Stimfit <http://www.stimfit.org>`_ |version| under GNU/Linux. The installation was tested on a GNU/Debian testing/unstable with support for Python 2.*. It should work on other Debian-based systems (e.g. Ubuntu) as with newer version of Stimfit as well. I assume that you have the GNU C compiler (gcc) and the GNU C++ compiler (g++) and that both versions match. For this installation, we tested 4.2.4versions.
+This document describes how to install `Stimfit <http://www.stimfit.org>`_ |version| under GNU/Linux. The installation was tested on a GNU/Debian testing/unstable with support for Python 2.*. It should work on other Debian-based systems (e.g. Ubuntu) as with newer version of Stimfit as well. I assume that you have the GNU C compiler (gcc) and the GNU C++ compiler (g++) and that both versions match. For this installation, we tested 4.2.4 versions.
 
 ============================
 What we need before we start
@@ -51,7 +51,7 @@ In addition, you can install doxygen, python-sphinx (with graphviz and Latex) if
 Optional: PyEMF
 =======================
 
-[PyEMF]_ is needed to export figures to the windows meta fileformat (WMF/EMF). EMF is a vector graphics format and can be imported in different Office software including LibreOffice. To install it, do:
+[PyEMF]_ is needed to export figures to the windows meta file format (WMF/EMF). EMF is a vector graphics format and can be imported in different Office software including LibreOffice. To install it, do:
 
 ::
 

--- a/doc/sphinx/linux_install_guide/requirement.rst
+++ b/doc/sphinx/linux_install_guide/requirement.rst
@@ -36,7 +36,7 @@ For the impatient, here are all `Stimfit <http://www.stimfit.org>`_ build depend
 
 This will get you, amongst others:
 
-* [wxWidgets]_: C++ library that contains the user interface (version 2.8 is only recommended!)
+* [wxWidgets]_: C++ library that contains the user interface (version = 2.8.12 , but 3.0.4 is highly recommended!)
 * [wxPython]_: GUI toolkit for the Python language.
 * [boost]_: C++ library that is mainly used for its shared pointers.
 * [Lapack]_: A linear algebra library.

--- a/doc/sphinx/linux_install_guide/requirement.rst
+++ b/doc/sphinx/linux_install_guide/requirement.rst
@@ -36,7 +36,7 @@ For the impatient, here are all `Stimfit <http://www.stimfit.org>`_ build depend
 
 This will get you, amongst others:
 
-* [wxWidgets]_: C++ library that contains the user interface (version >= 2.8). Tested with 2.8.12 and 3.0.4)
+* [wxWidgets]_: C++ graphical user interface toolkit (version >= 2.8). Tested with 2.8.12 and 3.0.4)
 * [wxPython]_: GUI toolkit for the Python language.
 * [boost]_: C++ library that is mainly used for its shared pointers.
 * [Lapack]_: A linear algebra library.

--- a/doc/sphinx/linux_install_guide/requirement.rst
+++ b/doc/sphinx/linux_install_guide/requirement.rst
@@ -36,7 +36,7 @@ For the impatient, here are all `Stimfit <http://www.stimfit.org>`_ build depend
 
 This will get you, amongst others:
 
-* [wxWidgets]_: C++ library that contains the user interface (version = 2.8.12 , but 3.0.4 is highly recommended!)
+* [wxWidgets]_: C++ library that contains the user interface (version >= 2.8). Tested with 2.8.12 and 3.0.4)
 * [wxPython]_: GUI toolkit for the Python language.
 * [boost]_: C++ library that is mainly used for its shared pointers.
 * [Lapack]_: A linear algebra library.

--- a/doc/sphinx/linux_install_guide/requirement.rst
+++ b/doc/sphinx/linux_install_guide/requirement.rst
@@ -5,7 +5,7 @@ Building Stimfit
 :Author: Jose Guzman, Christoph Schmidt-Hieber
 :Date:    |today|
 
-This document describes how to install `Stimfit <http://www.stimfit.org>`_ |version| under GNU/Linux. The installation was tested on a GNU/Debian testing/unstable system, with a 2.6-based kernel and with support for Python 2.5. and Python 2.6. It should work on other Debian-based systems (e.g Ubuntu) aswith newer version of Stimfit as well. I assume that you have the GNU C compiler (gcc) and the GNU C++ compiler (g++) already installed in your system. Please, check that both versions match. For our installation we will use gcc-4.2.4 and the same version of g++.
+This document describes how to install `Stimfit <http://www.stimfit.org>`_ |version| under GNU/Linux. The installation was tested on a GNU/Debian testing/unstable with support for Python 2.*. It should work on other Debian-based systems (e.g. Ubuntu) as with newer version of Stimfit as well. I assume that you have the GNU C compiler (gcc) and the GNU C++ compiler (g++) and that both versions match. For this installation, we tested 4.2.4versions.
 
 ============================
 What we need before we start
@@ -36,19 +36,22 @@ For the impatient, here are all `Stimfit <http://www.stimfit.org>`_ build depend
 
 This will get you, amongst others:
 
+* [wxWidgets]_: C++ library that contains the user interface (version 2.8 is only recommended!)
+* [wxPython]_: GUI toolkit for the Python language.
 * [boost]_: C++ library that is mainly used for its shared pointers.
 * [Lapack]_: A linear algebra library.
 * [fftw]_:  Library for computing Fourier transformations.
-* [NumPy]_: To handle multidimensional arrays and perform more complex numerical computations with Python.
-* [HDF5]_: This is the hierarchical Data Format 5 (HDF5) to manage large amount of data.
+* [NumPy]_: To handle numerical computations with Python (use version >=1.7.1).
+* [HDF5]_: Hierarchical Data Format 5 (HDF5) to manage large amount of data.
+* [Matplotlib]_: Plotting library for Python (use version >= 1.5.1)
 
-In addition, you can install doxygen, python-sphinx and graphviz if you want to build the documentation.
+In addition, you can install doxygen, python-sphinx (with graphviz and Latex) if you want to build the documentation.
 
 =======================
 Optional: PyEMF
 =======================
 
-[PyEMF]_ is needed to export figures to the windows meta file format (WMF/EMF). EMF is a vector graphics format and can be imported in different Office software including LibreOffice. In order to install it, do:
+[PyEMF]_ is needed to export figures to the windows meta fileformat (WMF/EMF). EMF is a vector graphics format and can be imported in different Office software including LibreOffice. To install it, do:
 
 ::
 
@@ -91,8 +94,7 @@ to generate the configure script. Remember that we need Autoconf, Automake and L
 
     $ ./configure --enable-python
 
-The **--enable-python** option is absolutely necessary to install `Stimfit <http://www.stimfit.org>`_ since some of the functionality depends on Python. The configure script has some additional options. For example, we may want to use `IPython <http://www.scipy.org>`_  instead of the default embedded python shell with the option **---enable-ipython**  (note that the `IPython <http://www.scipy.org>`_ shell is only available under GNU/Linux and it is still very experimental). 
-
+The **--enable-python** option is absolutely necessary to install `Stimfit <http://www.stimfit.org>`_ since some of the functionality depends on Python. The configure script has some additional options. 
 
 
 Finally, after running configure, you can type
@@ -141,7 +143,7 @@ We recommend to build `Stimfit <http://www.stimfit.org>`_  with the `BioSig libr
 
 ::
 
-    cd biosig-code/biosig4c+
+    cd biosig-code/biosig4c++
     autoconf # needed first time after getting repository
     ./configure
     make 
@@ -153,7 +155,7 @@ After that you can enter the option --with-biosig in the configure script of `St
 Building documentation
 ======================
 
-The manual of `Stimfit <http://www.stimfit.org>`_ including the documentation is accessible on-line in http://www.stimfit.org/doc/sphix/. To have your local copy, you will need to install sphinx:
+The manual of `Stimfit <http://www.stimfit.org>`_ including the documentation is accessible on-line in http://www.stimfit.org/doc/sphix/. To have your local copy, you will need to install sphinx version 1.7 or older:
 
 ::
 
@@ -188,6 +190,7 @@ The local documentation of the source code will be in $HOME/stimfit/doc/doxygen/
 .. [Lapack] http://www.netlib.org/lapack/
 .. [HDF5] http://www.hdfgroup.org/HDF5/
 .. [NumPy] http://www.numpy.org
-.. [PyEMF] http://http://pyemf.sourceforge.net
+.. [PyEMF] http://pyemf.sourceforge.net
 .. [fftw] http://www.fftw.org
 .. [Doxygen] http://www.doxygen.org
+.. [Matplotlib] https://matplotlib.org

--- a/doc/sphinx/manual/python.rst
+++ b/doc/sphinx/manual/python.rst
@@ -158,7 +158,7 @@ You can pass a 2D-NumPy array to :func:`stf.new_window_matrix()`. The first dime
     >>> numpy_matrix[1] = np.sqrt( np.abs(get_trace()) )
     >>> new_window_matrix(numpy_matrix)
 
-In this example, np is the NumPy namespace. Typing np. at the command prompt will show you all available NumPy functions. :func:`stf.get_size_trace()` will be explained later on.
+In this example, np is the [NumPy]_ namespace. Typing np. at the command prompt will show you all available [NumPy]_ functions. :func:`stf.get_size_trace()` will be explained later on.
 
 * **new_window_list()**
 
@@ -394,7 +394,7 @@ Cutting traces is best done using the squared braked operators ([]) to slice a [
     >>> new_window(a[:100])
     >>> new_window(a[100:])
 
-In this example, a[:100] refers to a sliced NumPy array that comprises all sampling points from index 0 to index 99, and a[100:] refers to an array from index 100 to the last sampling point.
+In this example, a[:100] refers to a sliced [NumPy]_ array that comprises all sampling points from index 0 to index 99, and a[100:] refers to an array from index 100 to the last sampling point.
 
 * **cut_traces(pt)** and **cut_traces_multi(pt_list)**
 
@@ -452,5 +452,4 @@ will cut the selected traces at every 100th sampling point, starting with the 10
 
 .. [Python-tutorial] http://docs.python.org/tut/
 .. [Python-website]  http://www.python.org/doc/
-.. [NumPy] http://numpy.scipy.org/
 .. [SciPy] http://www.scipy.org/

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,1 +1,1 @@
-sphinx>=1.4.3
+sphinx>=1.7


### PR DESCRIPTION
I indicated the equirements for wxWidgets = 2.8, matplotlib => 1.5, Numpy =>1.7 etc. Otherwise the installation will not work, or will return the famous error when loading the Python shell.